### PR TITLE
feat: add HandleGrpcError function

### DIFF
--- a/pkg/grpc/handleError.go
+++ b/pkg/grpc/handleError.go
@@ -55,6 +55,11 @@ func HandleGrpcErrorIgnoringNotFound(ctx context.Context, err error) error {
 				Message: "internal error",
 				Status:  http.StatusInternalServerError,
 			}))
+		case codes.AlreadyExists:
+			return thunderGraphql.HandleError(ctx, roxy.SetDefaultHTTPResponse(err, roxy.HTTPResponse{
+				Message: statusCode.Message(),
+				Status:  http.StatusConflict,
+			}))
 		default:
 			return thunderGraphql.HandleError(ctx, roxy.SetDefaultHTTPResponse(err, roxy.HTTPResponse{
 				Message: "internal error",
@@ -113,6 +118,11 @@ func HandleGrpcError(ctx context.Context, err error) error {
 			return thunderGraphql.HandleError(ctx, roxy.SetDefaultHTTPResponse(err, roxy.HTTPResponse{
 				Message: "internal error",
 				Status:  http.StatusInternalServerError,
+			}))
+		case codes.AlreadyExists:
+			return thunderGraphql.HandleError(ctx, roxy.SetDefaultHTTPResponse(err, roxy.HTTPResponse{
+				Message: statusCode.Message(),
+				Status:  http.StatusConflict,
 			}))
 		default:
 			return thunderGraphql.HandleError(ctx, roxy.SetDefaultHTTPResponse(err, roxy.HTTPResponse{

--- a/pkg/grpc/handleError.go
+++ b/pkg/grpc/handleError.go
@@ -2,9 +2,12 @@ package grpc
 
 import (
 	"context"
+	"errors"
+	"net/http"
 
 	"github.com/TheRafaBonin/roxy"
 
+	thunderGraphql "github.com/gothunder/thunder/pkg/graphql"
 	thunderLogger "github.com/gothunder/thunder/pkg/log"
 
 	"google.golang.org/grpc/codes"
@@ -26,4 +29,101 @@ func HandleError(ctx context.Context, err error) error {
 	// Log and return
 	thunderLogger.LogError(ctx, err)
 	return status.Error(grpcCode, grpcMessage)
+}
+
+func HandleGrpcErrorIgnoringNotFound(ctx context.Context, err error) error {
+	var bareStatusErr error
+	_, ok := err.(interface {
+		Unwrap() error
+	})
+	if !ok {
+		bareStatusErr = err
+	} else {
+		bareStatusErr = errors.Unwrap(err)
+	}
+	if statusCode, ok := status.FromError(bareStatusErr); ok {
+		switch statusCode.Code() {
+		case codes.NotFound:
+			return nil
+		case codes.InvalidArgument:
+			return thunderGraphql.HandleError(ctx, roxy.SetDefaultHTTPResponse(err, roxy.HTTPResponse{
+				Message: statusCode.Message(),
+				Status:  http.StatusBadRequest,
+			}))
+		case codes.Internal:
+			return thunderGraphql.HandleError(ctx, roxy.SetDefaultHTTPResponse(err, roxy.HTTPResponse{
+				Message: "internal error",
+				Status:  http.StatusInternalServerError,
+			}))
+		default:
+			return thunderGraphql.HandleError(ctx, roxy.SetDefaultHTTPResponse(err, roxy.HTTPResponse{
+				Message: "internal error",
+				Status:  http.StatusInternalServerError,
+			}))
+		}
+	} else {
+		return thunderGraphql.HandleError(ctx, roxy.SetDefaultHTTPResponse(err, roxy.HTTPResponse{
+			Message: "internal error",
+			Status:  http.StatusInternalServerError,
+		}))
+	}
+}
+
+func GetStatusCodeFromRawError(err error) codes.Code {
+	var bareStatusErr error
+	_, ok := err.(interface {
+		Unwrap() error
+	})
+	if !ok {
+		bareStatusErr = err
+	} else {
+		bareStatusErr = errors.Unwrap(err)
+	}
+
+	if statusCode, ok := status.FromError(bareStatusErr); ok {
+		return statusCode.Code()
+	}
+
+	return codes.Internal
+}
+
+func HandleGrpcError(ctx context.Context, err error) error {
+	var bareStatusErr error
+	_, ok := err.(interface {
+		Unwrap() error
+	})
+	if !ok {
+		bareStatusErr = err
+	} else {
+		bareStatusErr = errors.Unwrap(err)
+	}
+	if statusCode, ok := status.FromError(bareStatusErr); ok {
+		switch statusCode.Code() {
+		case codes.NotFound:
+			return thunderGraphql.HandleError(ctx, roxy.SetDefaultHTTPResponse(err, roxy.HTTPResponse{
+				Message: statusCode.Message(),
+				Status:  http.StatusNotFound,
+			}))
+		case codes.InvalidArgument:
+			return thunderGraphql.HandleError(ctx, roxy.SetDefaultHTTPResponse(err, roxy.HTTPResponse{
+				Message: statusCode.Message(),
+				Status:  http.StatusBadRequest,
+			}))
+		case codes.Internal:
+			return thunderGraphql.HandleError(ctx, roxy.SetDefaultHTTPResponse(err, roxy.HTTPResponse{
+				Message: "internal error",
+				Status:  http.StatusInternalServerError,
+			}))
+		default:
+			return thunderGraphql.HandleError(ctx, roxy.SetDefaultHTTPResponse(err, roxy.HTTPResponse{
+				Message: "internal error",
+				Status:  http.StatusInternalServerError,
+			}))
+		}
+	} else {
+		return thunderGraphql.HandleError(ctx, roxy.SetDefaultHTTPResponse(err, roxy.HTTPResponse{
+			Message: "internal error",
+			Status:  http.StatusInternalServerError,
+		}))
+	}
 }


### PR DESCRIPTION
- add HandleGrpcError function to transform grpc errors into graphql errors
- add HandleGrpcErrorIgnoringNotFound to do the same as HandleGrpcError but ignoring NotFound errors
- add GetStatusCodeFromRawError to extract status code from an error