### PR TITLE
feat: add unhealth warn to rabbitmq publisher

### DIFF
--- a/internal/events/rabbitmq/publisher/close.go
+++ b/internal/events/rabbitmq/publisher/close.go
@@ -23,6 +23,7 @@ func (r *rabbitmqPublisher) Close(ctx context.Context) error {
 	}
 
 	r.logger.Info().Msg("publisher closed gracefully")
+	r.closed.Store(true)
 	return nil
 }
 

--- a/internal/events/rabbitmq/publisher/health.go
+++ b/internal/events/rabbitmq/publisher/health.go
@@ -1,0 +1,80 @@
+package publisher
+
+import (
+	"sync"
+	"sync/atomic"
+	"time"
+)
+
+type waitGroupCount struct {
+	sync.WaitGroup
+	count int64
+}
+
+func (wg *waitGroupCount) Add(delta int) {
+	atomic.AddInt64(&wg.count, int64(delta))
+	wg.WaitGroup.Add(delta)
+}
+
+func (wg *waitGroupCount) Done() {
+	atomic.AddInt64(&wg.count, -1)
+	wg.WaitGroup.Done()
+}
+
+func (wg *waitGroupCount) GetCount() int64 {
+	return atomic.LoadInt64(&wg.count)
+}
+
+func newWaitGroupCounter() *waitGroupCount {
+	return &waitGroupCount{
+		WaitGroup: sync.WaitGroup{},
+		count:     0,
+	}
+}
+
+const (
+	timeWithoutPublishUnhealth = 30 * time.Second
+	timePausedUnhealth         = 30 * time.Second
+)
+
+func (r *rabbitmqPublisher) healthCheckLoop() {
+	logger := r.logger.With().Str("component", "publisher_health_check").Logger()
+
+	ticker := time.NewTicker(30 * time.Second)
+	defer ticker.Stop()
+	for {
+		<-ticker.C
+		if r.closed.Load() {
+			return
+		}
+
+		count := r.wg.GetCount()
+		logger.Debug().Int64("messages_unpublished", count).Msg("checking publisher health")
+
+		if r.isPaused() {
+			logger.Debug().Time("last_paused", r.getLastPausedAt()).Msg("publisher is paused")
+			if time.Since(r.getLastPausedAt()) > timePausedUnhealth {
+				logger.Warn().
+					Int64("messages_unpublished", count).
+					Time("last_paused", r.getLastPausedAt()).
+					Msg("publisher unhealthy: paused for too long")
+			}
+			continue
+		}
+
+		if count == 0 {
+			logger.Debug().Msg("no messages pending, skipping")
+			continue
+		}
+
+		r.lastPublishedAtMux.RLock()
+		lastPublishedAt := r.lastPublishedAt
+		r.lastPublishedAtMux.RUnlock()
+		if time.Since(lastPublishedAt) > timeWithoutPublishUnhealth {
+			logger.Warn().
+				Int64("messages_unpublished", count).
+				Time("last_published", lastPublishedAt).
+				Msg("publisher unhealthy: no publishing for too long")
+		}
+	}
+}

--- a/internal/events/rabbitmq/publisher/notifications.go
+++ b/internal/events/rabbitmq/publisher/notifications.go
@@ -32,17 +32,12 @@ func (r *rabbitmqPublisher) handleNotifyBlocked() {
 	)
 
 	for blocking := range notifyBlockedChan {
-		r.pausePublishMux.Lock()
 		if blocking.Active {
-			r.pausePublish = true
-			if len(r.pauseSignalChan) == 0 {
-				r.pauseSignalChan <- true
-			}
+			r.pause()
 			r.logger.Warn().Msg("pausing publishing due to TCP blocking from server")
 		} else {
-			r.pausePublish = false
+			r.resume()
 			r.logger.Warn().Msg("resuming publishing due to TCP unblocking from server")
 		}
-		r.pausePublishMux.Unlock()
 	}
 }

--- a/internal/events/rabbitmq/publisher/pause.go
+++ b/internal/events/rabbitmq/publisher/pause.go
@@ -1,0 +1,35 @@
+package publisher
+
+import "time"
+
+func (r *rabbitmqPublisher) pause() {
+	r.pausePublishMux.Lock()
+	r.pausePublish = true
+	r.pausePublishMux.Unlock()
+
+	r.lastPausedAtMux.Lock()
+	r.lastPausedAt = time.Now()
+	r.lastPausedAtMux.Unlock()
+
+	if len(r.pauseSignalChan) == 0 {
+		r.pauseSignalChan <- true
+	}
+}
+
+func (r *rabbitmqPublisher) resume() {
+	r.pausePublishMux.Lock()
+	r.pausePublish = false
+	r.pausePublishMux.Unlock()
+}
+
+func (r *rabbitmqPublisher) isPaused() bool {
+	r.pausePublishMux.RLock()
+	defer r.pausePublishMux.RUnlock()
+	return r.pausePublish
+}
+
+func (r *rabbitmqPublisher) getLastPausedAt() time.Time {
+	r.lastPausedAtMux.RLock()
+	defer r.lastPausedAtMux.RUnlock()
+	return r.lastPausedAt
+}

--- a/internal/events/rabbitmq/publisher/publish.go
+++ b/internal/events/rabbitmq/publisher/publish.go
@@ -131,7 +131,17 @@ func (r *rabbitmqPublisher) publishMessage(msg message) {
 
 	log.Ctx(msg.Context).Info().Str("topic", msg.Topic).Msg("message published")
 	r.wg.Done()
+	r.updatePublishedAt()
+}
+
+func (r *rabbitmqPublisher) updatePublishedAt() {
 	r.lastPublishedAtMux.Lock()
 	r.lastPublishedAt = time.Now()
 	r.lastPublishedAtMux.Unlock()
+}
+
+func (r *rabbitmqPublisher) getLastPublishedAt() time.Time {
+	r.lastPublishedAtMux.RLock()
+	defer r.lastPublishedAtMux.RUnlock()
+	return r.lastPublishedAt
 }

--- a/internal/events/rabbitmq/publisher/startPublisher.go
+++ b/internal/events/rabbitmq/publisher/startPublisher.go
@@ -8,6 +8,7 @@ import (
 
 func (r *rabbitmqPublisher) StartPublisher(ctx context.Context) error {
 	go r.proccessingLoop()
+	go r.healthCheckLoop()
 
 	for {
 		err := r.chManager.Channel.Confirm(false)
@@ -16,9 +17,7 @@ func (r *rabbitmqPublisher) StartPublisher(ctx context.Context) error {
 		}
 		r.listenForNotifications()
 
-		r.pausePublishMux.Lock()
-		r.pausePublish = false
-		r.pausePublishMux.Unlock()
+		r.resume()
 
 		// Wait for reconnection
 		err = <-r.chManager.NotifyReconnection

--- a/internal/log/correlationIDHook.go
+++ b/internal/log/correlationIDHook.go
@@ -14,6 +14,6 @@ func (h CorrelationIDHook) Run(e *zerolog.Event, level zerolog.Level, msg string
 	ctx := e.GetCtx()
 	correlationID := thunderContext.CorrelationIDFromContext(ctx)
 	if correlationID != "" {
-		e.Str("correlation-id", correlationID)
+		e.Str("correlation_id", correlationID)
 	}
 }

--- a/internal/log/tracingHook.go
+++ b/internal/log/tracingHook.go
@@ -18,5 +18,5 @@ func (h TracingHook) Run(e *zerolog.Event, level zerolog.Level, msg string) {
 	spanID := spanContext.SpanID().String()
 	traceID := spanContext.TraceID().String()
 
-	e.Str("trace-id", traceID).Str("span-id", spanID)
+	e.Str("trace_id", traceID).Str("span_id", spanID)
 }


### PR DESCRIPTION
# What it does

It add a health check loop on the rabbitmq publisher that checks and logs possible issues regarding the health of the publisher:
- paused for too long
- no publishing for too long (when there is pending messages)


