### PR TITLE
fix(graphql): return fresh internal errors

### DIFF
--- a/internal/graphql/errorPresenter.go
+++ b/internal/graphql/errorPresenter.go
@@ -43,5 +43,5 @@ func errorPresenter(ctx context.Context, err error) *gqlerror.Error {
 		Str("query", query).
 		Msg("response not provided")
 
-	return internalError
+	return newInternalError()
 }

--- a/internal/graphql/errorPresenter_test.go
+++ b/internal/graphql/errorPresenter_test.go
@@ -1,0 +1,47 @@
+package graphql
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/vektah/gqlparser/v2/ast"
+	"github.com/vektah/gqlparser/v2/gqlerror"
+)
+
+func TestErrorPresenterReturnsFreshInternalErrors(t *testing.T) {
+	first := errorPresenter(context.Background(), errors.New("resolver failed"))
+	first.Path = ast.Path{ast.PathName("stale")}
+
+	second := errorPresenter(context.Background(), errors.New("another resolver failed"))
+
+	if first == second {
+		t.Fatal("errorPresenter returned a shared error instance")
+	}
+	if len(second.Path) != 0 {
+		t.Fatalf("fresh error inherited stale path: %#v", second.Path)
+	}
+	if status, ok := second.Extensions["status"].(int); !ok || status != 500 {
+		t.Fatalf("unexpected internal error status: %#v", second.Extensions)
+	}
+}
+
+func TestRecoverFuncReturnsFreshInternalErrors(t *testing.T) {
+	first, ok := recoverFunc(context.Background(), errors.New("first panic")).(*gqlerror.Error)
+	if !ok {
+		t.Fatal("recoverFunc did not return a GraphQL error")
+	}
+	first.Path = ast.Path{ast.PathName("stale")}
+
+	second, ok := recoverFunc(context.Background(), errors.New("second panic")).(*gqlerror.Error)
+	if !ok {
+		t.Fatal("recoverFunc did not return a GraphQL error")
+	}
+
+	if first == second {
+		t.Fatal("recoverFunc returned a shared error instance")
+	}
+	if len(second.Path) != 0 {
+		t.Fatalf("fresh panic error inherited stale path: %#v", second.Path)
+	}
+}

--- a/internal/graphql/register.go
+++ b/internal/graphql/register.go
@@ -45,10 +45,7 @@ func CreateHandler(graphQLSchema graphql.ExecutableSchema) *handler.Server {
 	graphqlHandler.SetErrorPresenter(errorPresenter)
 
 	// Set the panic handler
-	graphqlHandler.SetRecoverFunc(func(ctx context.Context, p interface{}) error {
-		recoverer.Recoverer(ctx, p)
-		return internalError
-	})
+	graphqlHandler.SetRecoverFunc(recoverFunc)
 
 	// Add a middleware to log the request
 	graphqlHandler.AroundOperations(aroundOperations)
@@ -59,10 +56,16 @@ func CreateHandler(graphQLSchema graphql.ExecutableSchema) *handler.Server {
 	return graphqlHandler
 }
 
-// A default internal error when something goes wrong
-var internalError *gqlerror.Error = &gqlerror.Error{
-	Message: http.StatusText(http.StatusInternalServerError),
-	Extensions: map[string]interface{}{
-		"status": http.StatusInternalServerError,
-	},
+func recoverFunc(ctx context.Context, p interface{}) error {
+	recoverer.Recoverer(ctx, p)
+	return newInternalError()
+}
+
+func newInternalError() *gqlerror.Error {
+	return &gqlerror.Error{
+		Message: http.StatusText(http.StatusInternalServerError),
+		Extensions: map[string]interface{}{
+			"status": http.StatusInternalServerError,
+		},
+	}
 }


### PR DESCRIPTION
## Why this is needed

Thunder v1.3.1 reuses one package-level `*gqlerror.Error` for both fallback presentation and panic recovery. gqlgen mutates a GraphQL error’s `Path` in place when attaching the resolver path.

A single field-level panic can therefore stamp its path onto the shared error; every later unrelated internal error returned by that process inherits the stale path. The payload becomes false operational evidence and can misidentify the failing operation until restart.

## Change

Allocate a fresh internal GraphQL error for every fallback presentation and every recovered panic. The response message and HTTP-status extension remain unchanged; only error-instance ownership changes.

## Verification

`go test ./internal/graphql` proves separate fallback and recovery errors do not share a pointer or retain a mutated path.